### PR TITLE
Add a generalized wiki url page attribute for all repos.

### DIFF
--- a/src/partials/toc.hbs
+++ b/src/partials/toc.hbs
@@ -59,6 +59,11 @@
           <svg viewBox="0 0 500 500" xmlns="http://www.w3.org/2000/svg"><circle cx="250" cy="250" r="193" fill="none" stroke="currentColor" stroke-width="23" stroke-miterlimit="10"/><circle cx="148.5" cy="250" r="31.5" fill="currentColor"/><circle cx="250" cy="250" r="31.5" fill="currentColor"/><circle cx="351.5" cy="250" r="31.5" fill="currentColor"/></svg>
           More Details
         </a>
+      {{else if page.attributes.wiki_url}}
+        <a href="{{page.attributes.wiki_url}}" target="_blank" rel="noopener noreferrer" class="sidebar-link">
+          <svg viewBox="0 0 500 500" xmlns="http://www.w3.org/2000/svg"><circle cx="250" cy="250" r="193" fill="none" stroke="currentColor" stroke-width="23" stroke-miterlimit="10"/><circle cx="148.5" cy="250" r="31.5" fill="currentColor"/><circle cx="250" cy="250" r="31.5" fill="currentColor"/><circle cx="351.5" cy="250" r="31.5" fill="currentColor"/></svg>
+          More Details
+        </a>
       {{/if}}
 
       {{#if (eq page.module "unpriv")}}


### PR DESCRIPTION
For repos that are not riscv-isa-manual they require a single wiki url asciidoc attribute in order to populate More Details appropriately.